### PR TITLE
Remove bower package requirement.

### DIFF
--- a/blueprints/ember-cli-clipboard/index.js
+++ b/blueprints/ember-cli-clipboard/index.js
@@ -1,9 +1,0 @@
-module.exports = {
-  description: 'install ember-cli-clipboard into a typical project',
-
-  normalizeEntityName: function() {},
-
-  afterInstall: function (options) {
-    return this.addBowerPackageToProject('clipboard', '~1.5.5');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "clipboard": "~1.5.5",
     "highlightjs": "8.8.0",
     "font-awesome": "~4.4.0",
     "es5-shim": "^4.0.5"

--- a/index.js
+++ b/index.js
@@ -1,17 +1,27 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
+
 module.exports = {
   name: 'ember-cli-clipboard',
 
+  treeForVendor: function() {
+    var Funnel = require('broccoli-funnel');
+    var clipboardPath = path.join(path.dirname(require.resolve('clipboard')), '..');
+
+    return new Funnel(this.treeGenerator(clipboardPath), {
+      destDir: 'clipboard'
+    });
+  },
+
   included: function included(app) {
-    this.app = app;
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     if (process.env.EMBER_CLI_FASTBOOT) {
       return;
     }
 
-    app.import(app.bowerDirectory + '/clipboard/dist/clipboard.js');
+    app.import('vendor/clipboard/dist/clipboard.js');
   }
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "clipboard"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.0.1",
+    "clipboard": "^1.5.10",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "0.7.9"
   },


### PR DESCRIPTION
This replaces the blueprint adding `clipboard.js` to the consuming applications bower dependencies, with a direct NPM dependency.

This will help as ember-cli continues its migration away from bower (and eventually removes bower support from the core into an optional addon).