### PR TITLE
Add support for disabled attribute

### DIFF
--- a/addon/components/copy-button.js
+++ b/addon/components/copy-button.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import layout from '../templates/components/copy-button';
 /* global Clipboard */
 
-const { get, set } = Ember;
+const { get, run, set } = Ember;
 
 export default Ember.Component.extend({
   layout: layout,
@@ -12,7 +12,8 @@ export default Ember.Component.extend({
     'clipboardText:data-clipboard-text',
     'clipboardTarget:data-clipboard-target',
     'clipboardAction:data-clipboard-action',
-    'buttonType:type'
+    'buttonType:type',
+    'disabled'
   ],
 
   /**
@@ -25,14 +26,21 @@ export default Ember.Component.extend({
    */
   buttonType: 'button',
 
+  /**
+   * @property {Boolean} disabled - disabled state for button element
+   */
+  disabled: false,
+
   didInsertElement() {
     let clipboard = new Clipboard(`#${this.get('elementId')}`);
     set(this, 'clipboard', clipboard);
 
     get(this, 'clipboardEvents').forEach(action => {
-      clipboard.on(action, Ember.run.bind(this, function(e) {
+      clipboard.on(action, run.bind(this, e => {
         try {
-          this.sendAction(action, e);
+          if (!this.get('disabled')) {
+            this.sendAction(action, e);
+          }
         }
         catch(error) {
           Ember.Logger.debug(error.message);

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -69,14 +69,29 @@ test('error action fires', function(assert) {
   this.$('button').click();
 });
 
+test('button is not disabled by default', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#copy-button}}
+      Click To Copy
+    {{/copy-button}}
+  `);
+
+  assert.equal(this.$('.copy-btn').attr('disabled'),
+    undefined,
+  'disabled correctly bound to type');
+});
+
 test('attributeBindings', function(assert) {
-  assert.expect(4);
+  assert.expect(5);
 
   this.render(hbs`
     {{#copy-button
       clipboardText='text'
       clipboardAction='cut'
       clipboardTarget='.foo'
+      disabled=true
     }}
       Click To Copy
     {{/copy-button}}
@@ -99,4 +114,8 @@ test('attributeBindings', function(assert) {
   assert.equal(btn.attr('type'),
     'button',
   'buttonType correctly bound to type');
+
+  assert.equal(btn.attr('disabled'),
+    'disabled',
+  'disabled correctly bound to type');
 });


### PR DESCRIPTION
This PR adds support for using disabling `copy-button` using something like:
```
{{#copy-button disabled=true ...}}
  Button text
{{/copy-button}}
```

The `disabled` property defaults to `false`.