### PR TITLE
Add a helper to check clipboard.js is supported or not

### DIFF
--- a/addon/helpers/is-clipboard-supported.js
+++ b/addon/helpers/is-clipboard-supported.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
 /* global Clipboard */
 
-export const isClipboardSupported = Clipboard.isSupported();
-export default Ember.Helper.helper(() => isClipboardSupported);
+export const isClipboardSupported = Clipboard.isSupported;
+export default Ember.Helper.helper(isClipboardSupported);

--- a/addon/helpers/is-clipboard-supported.js
+++ b/addon/helpers/is-clipboard-supported.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+/* global Clipboard */
+
+export const isClipboardSupported = Clipboard.isSupported();
+export default Ember.Helper.helper(() => isClipboardSupported);

--- a/app/helpers/is-clipboard-supported.js
+++ b/app/helpers/is-clipboard-supported.js
@@ -1,0 +1,1 @@
+export { default, isClipboardSupported } from 'ember-cli-clipboard/helpers/is-clipboard-supported';

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "broccoli-funnel": "^1.1.0",
-    "clipboard": "^1.5.10",
+    "clipboard": "^1.6.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1"
   },

--- a/tests/acceptance/test-helpers-test.js
+++ b/tests/acceptance/test-helpers-test.js
@@ -4,12 +4,15 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 moduleForAcceptance('Acceptance | test helpers');
 
 test('test-helpers', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   visit('/');
   andThen(() => {
     assert.notOk(!!find('.alert').length,
       'no alert message is initially present');
+
+    assert.ok(find('.if-supported .container-body').text().match(/Clipboard is( not)? supported/),
+      'whether clipboard is supported is shown');
   });
 
   triggerCopySuccess();

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -31,15 +31,13 @@
       <div class="container-body">
         <div class="install-wrapper">
           <code class="install-cmd">ember install ember-cli-clipboard</code>
-          {{#if (is-clipboard-supported)}}
-            {{#copy-button
-              clipboardText="ember install ember-cli-clipboard"
-              success=(action "copyDirectSuccess")
-              error=(action "copyDirectError")
-            }}
-              {{fa-icon "copy" size=2}}
-            {{/copy-button}}
-          {{/if}}
+          {{#copy-button
+            clipboardText="ember install ember-cli-clipboard"
+            success=(action "copyDirectSuccess")
+            error=(action "copyDirectError")
+          }}
+            {{fa-icon "copy" size=2}}
+          {{/copy-button}}
         </div>
       </div>
       {{#code-block}}
@@ -126,6 +124,28 @@
 }}
   Cut Text
 \{{/copy-button}}
+      {{/code-block}}
+    </div>
+  </section>
+
+  <section>
+    <div class="container if-supported">
+      <p class="container-header">
+        Check If Clipboard Is Supported
+      </p>
+      <div class="container-body">
+        {{#if (is-clipboard-supported)}}
+          Clipboard is supported
+        {{else}}
+          Clipboard is not supported
+        {{/if}}
+      </div>
+      {{#code-block}}
+\{{#if (is-clipboard-supported)}}
+  Clipboard is supported
+\{{else}}
+  Clipboard is not supported
+\{{/if}}
       {{/code-block}}
     </div>
   </section>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -31,13 +31,15 @@
       <div class="container-body">
         <div class="install-wrapper">
           <code class="install-cmd">ember install ember-cli-clipboard</code>
-          {{#copy-button
-            clipboardText="ember install ember-cli-clipboard"
-            success=(action "copyDirectSuccess")
-            error=(action "copyDirectError")
-          }}
-            {{fa-icon "copy" size=2}}
-          {{/copy-button}}
+          {{#if (is-clipboard-supported)}}
+            {{#copy-button
+              clipboardText="ember install ember-cli-clipboard"
+              success=(action "copyDirectSuccess")
+              error=(action "copyDirectError")
+            }}
+              {{fa-icon "copy" size=2}}
+            {{/copy-button}}
+          {{/if}}
         </div>
       </div>
       {{#code-block}}

--- a/tests/unit/helpers/is-clipboard-supported-test.js
+++ b/tests/unit/helpers/is-clipboard-supported-test.js
@@ -1,0 +1,11 @@
+import { isClipboardSupported } from 'dummy/helpers/is-clipboard-supported';
+import { module, test } from 'qunit';
+/* global Clipboard */
+
+module('Unit | Helper | is clipboard supported');
+
+test('isClipboardSupported works same as Clipboard.isSupported', function(assert) {
+  assert.equal(isClipboardSupported(), Clipboard.isSupported());
+  assert.equal(isClipboardSupported('copy'), Clipboard.isSupported('copy'));
+  assert.equal(isClipboardSupported('cut'), Clipboard.isSupported('cut'));
+});


### PR DESCRIPTION
Hello.
Occasionally, I want to check whether the user agent supports clipboard.js. So I've added the helper.