### PR TITLE
Only fetch 'clipboardText' when needed

### DIFF
--- a/addon/components/copy-button.js
+++ b/addon/components/copy-button.js
@@ -9,7 +9,6 @@ export default Ember.Component.extend({
   tagName: 'button',
   classNames: ['copy-btn'],
   attributeBindings: [
-    'clipboardText:data-clipboard-text',
     'clipboardTarget:data-clipboard-target',
     'clipboardAction:data-clipboard-action',
     'buttonType:type',
@@ -34,7 +33,12 @@ export default Ember.Component.extend({
   disabled: false,
 
   didInsertElement() {
-    let clipboard = new Clipboard(`#${this.get('elementId')}`);
+    let clipboard = new Clipboard(
+      `#${this.get('elementId')}`,
+      {
+        text: () => this.get('clipboardText')
+      }
+    );
     set(this, 'clipboard', clipboard);
 
     get(this, 'clipboardEvents').forEach(action => {

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
 
 import {
   triggerError,
@@ -74,6 +75,29 @@ test('error action fires', function(assert) {
   this.$('button').click();
 });
 
+
+test('component lazyily computes', function(assert) { 
+  assert.expect(1);
+  
+  let obj = Ember.Object.create({
+    hasBeenCalled: false,
+    
+    value: Ember.computed(function(){
+      this.set('hasBeenCalled', true);
+      return 42;
+  });
+    
+  this.set('obj', obj);
+    
+  this.render(hbs`
+    {{#copy-button clipboardText=obj.value}}
+      Click To Copy
+    {{/copy-button}}
+  `);
+  
+  assert.notOk(obj.get('hasBeenCalled'), 'value not lazily bound');
+});
+
 test('test-helpers fire correct actions', function(assert) {
   assert.expect(2);
 
@@ -128,7 +152,6 @@ test('attributeBindings', function(assert) {
 
   this.render(hbs`
     {{#copy-button
-      clipboardText='text'
       clipboardAction='cut'
       clipboardTarget='.foo'
       disabled=true
@@ -140,10 +163,6 @@ test('attributeBindings', function(assert) {
   `);
 
   let btn = this.$('.copy-btn');
-
-  assert.equal(btn.attr('data-clipboard-text'),
-    'text',
-  'clipboardText correctly bound to data-clipboard-text');
 
   assert.equal(btn.attr('data-clipboard-target'),
     '.foo',

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -79,14 +79,14 @@ test('error action fires', function(assert) {
 test('component lazyily computes', function(assert) { 
   assert.expect(1);
   
-  let obj = Ember.Object.create({
+  let obj = Ember.Object.extend({
     hasBeenCalled: false,
     
     value: Ember.computed(function(){
       this.set('hasBeenCalled', true);
       return 42;
     })
-  });
+  }).create();
     
   this.set('obj', obj);
     

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -85,6 +85,7 @@ test('component lazyily computes', function(assert) {
     value: Ember.computed(function(){
       this.set('hasBeenCalled', true);
       return 42;
+    })
   });
     
   this.set('obj', obj);


### PR DESCRIPTION
the `clipboardText` attribute is resolved immediately and set as an attribute. This is quick, but what if you have lots of elements and 'clipboardText' is a computed property? Resolving and computing them is wasteful, can we only do it when the user actually needs it?