### PR TITLE
Fix Chrome headless problem on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: false
+sudo: true
 dist: trusty
 
 addons:


### PR DESCRIPTION
This PR fixes the following Travis CI error:
> not ok 1 Chrome - error
    ---
        message: >
            Error: Browser exited unexpectedly
            Non-zero exit code: null
            Stderr: 
             [0125/024934.996602:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/google/chrome/chrome-sandbox is owned by root and has mode 4755.

See:
 - workaround: https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524