### PR TITLE
Scope event listener to copy button node

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ http://jkusa.github.io/ember-cli-clipboard
 * `clipboardText` - string value to be copied
 * `clipboardTarget` - selector string of element from which to copy text
 * `clipboardAction` - string value of operation: `copy` or `cut` (default is copy)
+* `useClipboardNode` - boolean to scope element listener to copy-button component (default false)
 * `title` - string value of the button's [title attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title)
 * `buttonType` - string value of the button's [type attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes)
 * `disabled` - boolean value of the button's [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ http://jkusa.github.io/ember-cli-clipboard
 * `clipboardText` - string value to be copied
 * `clipboardTarget` - selector string of element from which to copy text
 * `clipboardAction` - string value of operation: `copy` or `cut` (default is copy)
-* `useClipboardNode` - boolean to scope element listener to copy-button component (default false)
+* `delegateClickEvent` - clipboard.js defaults event listeners to the body in order to reduce memory footprint if there are hundreds of event listeners on a page. If you want to scope the event listener to the copy button, set this property to `false`
 * `title` - string value of the button's [title attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title)
 * `buttonType` - string value of the button's [type attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes)
 * `disabled` - boolean value of the button's [disabled attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes)

--- a/addon/components/copy-button.js
+++ b/addon/components/copy-button.js
@@ -36,16 +36,16 @@ export default Component.extend({
   /**
    * If true - scope event listener to this element
    * If false - scope event listener to document.body (clipboardjs)
-   * @property {Boolean} useClipboardNode
+   * @property {Boolean} delegateClickEvent
    */
-  useClipboardNode: false,
+  delegateClickEvent: true,
 
   didInsertElement() {
     let clipboard;
-    if (get(this, 'useClipboardNode')) {
-      clipboard = new window.Clipboard(this.element);
+    if (!get(this, 'delegateClickEvent')) {
+      clipboard = new window.ClipboardJS(this.element);
     } else {
-      clipboard = new window.Clipboard(`#${this.get('elementId')}`);
+      clipboard = new window.ClipboardJS(`#${this.get('elementId')}`);
     }
     set(this, 'clipboard', clipboard);
 

--- a/addon/components/copy-button.js
+++ b/addon/components/copy-button.js
@@ -33,8 +33,20 @@ export default Component.extend({
    */
   disabled: false,
 
+  /**
+   * If true - scope event listener to this element
+   * If false - scope event listener to document.body (clipboardjs)
+   * @property {Boolean} useClipboardNode
+   */
+  useClipboardNode: false,
+
   didInsertElement() {
-    let clipboard = new window.ClipboardJS(`#${this.get('elementId')}`);
+    let clipboard;
+    if (get(this, 'useClipboardNode')) {
+      clipboard = new window.Clipboard(this.element);
+    } else {
+      clipboard = new window.Clipboard(`#${this.get('elementId')}`);
+    }
     set(this, 'clipboard', clipboard);
 
     get(this, 'clipboardEvents').forEach(action => {

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -30,6 +30,27 @@ test('component renders and cleans up', function(assert) {
   assert.notOk(!!this.$('.copy-btn').length, 'Component cleaned up');
 });
 
+test('component renders and cleans up with useClipboardNode', function(assert) {
+  assert.expect(2);
+
+  this.set('enabled', true);
+  this.render(hbs`
+    {{#if enabled}}
+      {{#copy-button
+        clipboardText='text'
+        useClipboardNode=true
+      }}
+        Click To Copy
+      {{/copy-button}}
+    {{/if}}
+  `);
+
+  assert.ok(!!this.$('.copy-btn').length, 'Component rendered');
+
+  this.set('enabled', false);
+  assert.notOk(!!this.$('.copy-btn').length, 'Component cleaned up');
+});
+
 test('components renders text', function(assert) {
   assert.expect(2);
 
@@ -74,6 +95,31 @@ test('error action fires', function(assert) {
   this.$('button').click();
 });
 
+test('error action fires with useClipboardNode', function(assert) {
+  assert.expect(1);
+
+  this.on('error', () => {
+    assert.ok(true, 'error action successfully called');
+  });
+
+  this.render(hbs`
+    {{#copy-button
+      clipboardText='text'
+      useClipboardNode=true
+      success='success'
+      error='error'
+    }}
+      Click To Copy
+    {{/copy-button}}
+  `);
+
+  /*
+   * Can only directly test error case here b/c browsers do not allow simulated
+   * clicks for `execCommand('copy')`. See test-helpers to test action integration.
+   */
+  this.$('button').click();
+});
+
 test('test-helpers fire correct actions', function(assert) {
   assert.expect(2);
 
@@ -89,6 +135,42 @@ test('test-helpers fire correct actions', function(assert) {
     {{#copy-button
       classNames='my-copy-btn'
       clipboardText='text'
+      success='success'
+      error=(action error)
+    }}
+      Click To Copy
+    {{/copy-button}}
+  `);
+
+  triggerError(this, '.my-copy-btn');
+
+  this.set('error', () => {
+    assert.notOk(true, 'error action incorrectly fired');
+  });
+
+  this.on('success', () => {
+    assert.ok(true, 'triggerSuccess correctly fired `success` action for selector');
+  });
+
+  triggerSuccess(this);
+});
+
+test('test-helpers fire correct actions with useClipboardNode', function(assert) {
+  assert.expect(2);
+
+  this.on('success', () => {
+    assert.notOk(true, 'success action incorrectly fired');
+  });
+
+  this.set('error', () => {
+    assert.ok(true, 'triggerError correctly fired `error` action for selector');
+  });
+
+  this.render(hbs`
+    {{#copy-button
+      classNames='my-copy-btn'
+      clipboardText='text'
+      useClipboardNode=true
       success='success'
       error=(action error)
     }}

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -95,6 +95,38 @@ test('error action fires', function(assert) {
   this.$('button').click();
 });
 
+test('click scoped to document.body', function(assert) {
+  assert.expect(2);
+
+  this.on('error', () => {
+    assert.ok(true, 'error action successfully called');
+  });
+
+  this.render(hbs`
+    <div class="bubble-me">
+      {{#copy-button
+        clipboardText='text'
+        success='success'
+        error='error'
+      }}
+        Click To Copy
+      {{/copy-button}}
+    </div>
+  `);
+
+  this.bubbleMe = () => assert.ok(true, 'bubbleMe was called');
+  let bubbleMe = document.querySelector('.bubble-me');
+  bubbleMe.addEventListener('click', this.bubbleMe, false);
+
+  /*
+   * Can only directly test error case here b/c browsers do not allow simulated
+   * clicks for `execCommand('copy')`. See test-helpers to test action integration.
+   */
+  this.$('button').click();
+
+  document.body.removeEventListener('click', this.bubbleMe, false);
+});
+
 test('error action fires with delegateClickEvent: false', function(assert) {
   assert.expect(1);
 

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -30,7 +30,7 @@ test('component renders and cleans up', function(assert) {
   assert.notOk(!!this.$('.copy-btn').length, 'Component cleaned up');
 });
 
-test('component renders and cleans up with useClipboardNode', function(assert) {
+test('component renders and cleans up with delegateClickEvent: false', function(assert) {
   assert.expect(2);
 
   this.set('enabled', true);
@@ -38,7 +38,7 @@ test('component renders and cleans up with useClipboardNode', function(assert) {
     {{#if enabled}}
       {{#copy-button
         clipboardText='text'
-        useClipboardNode=true
+        delegateClickEvent=false
       }}
         Click To Copy
       {{/copy-button}}
@@ -95,7 +95,7 @@ test('error action fires', function(assert) {
   this.$('button').click();
 });
 
-test('error action fires with useClipboardNode', function(assert) {
+test('error action fires with delegateClickEvent: false', function(assert) {
   assert.expect(1);
 
   this.on('error', () => {
@@ -105,7 +105,7 @@ test('error action fires with useClipboardNode', function(assert) {
   this.render(hbs`
     {{#copy-button
       clipboardText='text'
-      useClipboardNode=true
+      delegateClickEvent=false
       success='success'
       error='error'
     }}
@@ -135,42 +135,6 @@ test('test-helpers fire correct actions', function(assert) {
     {{#copy-button
       classNames='my-copy-btn'
       clipboardText='text'
-      success='success'
-      error=(action error)
-    }}
-      Click To Copy
-    {{/copy-button}}
-  `);
-
-  triggerError(this, '.my-copy-btn');
-
-  this.set('error', () => {
-    assert.notOk(true, 'error action incorrectly fired');
-  });
-
-  this.on('success', () => {
-    assert.ok(true, 'triggerSuccess correctly fired `success` action for selector');
-  });
-
-  triggerSuccess(this);
-});
-
-test('test-helpers fire correct actions with useClipboardNode', function(assert) {
-  assert.expect(2);
-
-  this.on('success', () => {
-    assert.notOk(true, 'success action incorrectly fired');
-  });
-
-  this.set('error', () => {
-    assert.ok(true, 'triggerError correctly fired `error` action for selector');
-  });
-
-  this.render(hbs`
-    {{#copy-button
-      classNames='my-copy-btn'
-      clipboardText='text'
-      useClipboardNode=true
       success='success'
       error=(action error)
     }}

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -95,38 +95,6 @@ test('error action fires', function(assert) {
   this.$('button').click();
 });
 
-test('click scoped to document.body', function(assert) {
-  assert.expect(2);
-
-  this.on('error', () => {
-    assert.ok(true, 'error action successfully called');
-  });
-
-  this.render(hbs`
-    <div class="bubble-me">
-      {{#copy-button
-        clipboardText='text'
-        success='success'
-        error='error'
-      }}
-        Click To Copy
-      {{/copy-button}}
-    </div>
-  `);
-
-  this.bubbleMe = () => assert.ok(true, 'bubbleMe was called');
-  let bubbleMe = document.querySelector('.bubble-me');
-  bubbleMe.addEventListener('click', this.bubbleMe, false);
-
-  /*
-   * Can only directly test error case here b/c browsers do not allow simulated
-   * clicks for `execCommand('copy')`. See test-helpers to test action integration.
-   */
-  this.$('button').click();
-
-  document.body.removeEventListener('click', this.bubbleMe, false);
-});
-
 test('error action fires with delegateClickEvent: false', function(assert) {
   assert.expect(1);
 
@@ -150,6 +118,67 @@ test('error action fires with delegateClickEvent: false', function(assert) {
    * clicks for `execCommand('copy')`. See test-helpers to test action integration.
    */
   this.$('button').click();
+});
+
+test('click scoped to document.body', function(assert) {
+  assert.expect(1);
+
+  this.on('error', () => {
+    assert.ok(true, 'error action successfully called');
+  });
+
+  this.render(hbs`
+    {{#copy-button
+      class="copy-button"
+      clipboardText='text'
+      success='success'
+      error='error'
+    }}
+      Click To Copy
+    {{/copy-button}}
+  `);
+
+  // even though remove node, document.body is still listening
+  let el = document.querySelector('.copy-button');
+  let clone = el.cloneNode(true);
+  el.parentNode.replaceChild(clone, el);
+
+  /*
+   * Can only directly test error case here b/c browsers do not allow simulated
+   * clicks for `execCommand('copy')`. See test-helpers to test action integration.
+   */
+  document.querySelector('.copy-button').click();
+});
+
+test('click scoped to element', function(assert) {
+  assert.expect(0);
+
+  this.on('error', () => {
+    assert.ok(false, 'listener should be removed');
+  });
+
+  this.render(hbs`
+    {{#copy-button
+      class="copy-button"
+      clipboardText='text'
+      delegateClickEvent=false
+      success='success'
+      error='error'
+    }}
+      Click To Copy
+    {{/copy-button}}
+  `);
+
+  // remove button and no assertions will be run
+  let el = document.querySelector('.copy-button');
+  let clone = el.cloneNode(true);
+  el.parentNode.replaceChild(clone, el);
+
+  /*
+   * Can only directly test error case here b/c browsers do not allow simulated
+   * clicks for `execCommand('copy')`. See test-helpers to test action integration.
+   */
+  document.querySelector('.copy-button').click();
 });
 
 test('test-helpers fire correct actions', function(assert) {


### PR DESCRIPTION
One problem I encountered is that by passing a string argument to clipboard, it listens for the click on `body`.  However, if I need to stop propagation (to prevent some other click handler higher up in the DOM from `copy-button`), one option is to pass a `node` to clipboardjs with `useClipboardNode=true` to pass `this.element` instead of a string.

Lmk what you think and if there is another way of doing this as well!

https://github.com/zenorocha/clipboard.js/blob/master/dist/clipboard.js#L351