### PR TITLE
Provide forward compatibility when accessing container

### DIFF
--- a/test-support/helpers/ember-cli-clipboard.js
+++ b/test-support/helpers/ember-cli-clipboard.js
@@ -79,7 +79,7 @@ function fireComponentAction(context, selector, actionName) {
  */
 function getComponentBySelector(context, selector='.copy-btn') {
   let emberId = context.$(selector).attr('id');
-  return context.container.lookup('-view-registry:main')[emberId];
+  return (context.container || context.owner).lookup('-view-registry:main')[emberId];
 }
 
 /**


### PR DESCRIPTION
`instance.lookup` supports Ember 2.1 and higher
`instance.container` supports Ember 1.11 - 2.0