### PR TITLE
clean up bower dependencies

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,9 @@ before_install:
   - npm config set spin false
   - npm install -g npm@6
   - npm --version
-  - npm install -g bower
-  - bower --version
 
 install:
   - npm install
-  - bower install
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "ember-cli-clipboard",
-  "dependencies": {
-    "highlightjs": "8.8.0"
-  }
-}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,8 +14,8 @@ module.exports = function(defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
-  app.import('bower_components/highlightjs/styles/github.css');
-  app.import('bower_components/highlightjs/highlight.pack.js');
+  app.import('node_modules/highlightjs/styles/github.css');
+  app.import('node_modules/highlightjs/highlight.pack.js');
 
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-fastboot": "^1.0.5",
     "ember-cli-flash": "^1.4.2",
     "ember-cli-github-pages": "0.1.2",
-    "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-htmlbars": "^2.0.2",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",
@@ -42,7 +42,8 @@
     "clipboard": "^2.0.0",
     "ember-cli-babel": "^6.8.0",
     "ember-cli-htmlbars": "^2.0.2",
-    "fastboot-transform": "0.1.1"
+    "fastboot-transform": "0.1.1",
+    "highlightjs": "^9.10.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Move bower dependencies to npm

The icon is from Octicons which has MIT license.