### PR TITLE
Native selector fallback

### DIFF
--- a/test-support/helpers/ember-cli-clipboard.js
+++ b/test-support/helpers/ember-cli-clipboard.js
@@ -79,7 +79,7 @@ function fireComponentAction(context, selector, actionName) {
  */
 function getComponentBySelector(context, selector='.copy-btn') {
   let emberId = context.$(selector).attr('id');
-  return context.container.lookup('-view-registry:main')[emberId];
+  return (context.container || context.owner).lookup('-view-registry:main')[emberId];
 }
 
 /**

--- a/test-support/helpers/ember-cli-clipboard.js
+++ b/test-support/helpers/ember-cli-clipboard.js
@@ -78,7 +78,14 @@ function fireComponentAction(context, selector, actionName) {
  * @returns {Object} component object
  */
 function getComponentBySelector(context, selector='.copy-btn') {
-  let emberId = context.$(selector).attr('id');
+  let emberId;
+
+  if(context.$){
+    emberId = context.$(selector).attr('id');
+  } else {
+    emberId = context.element.querySelector(selector).id
+  }
+
   return (context.container || context.owner).lookup('-view-registry:main')[emberId];
 }
 


### PR DESCRIPTION
Triggering success via `triggerSuccess()` test helper causes failure due to absence of `$` on `context` argument. Have you considered moving away from jQuery to native JS? 
We are providing a small quickfix to stop blocking us from migration to the latest jQuery-less ember.

We have already based this PR on another one which we provided earlier. It is the same piece of code and hence would case conflicts if we targeted master branch individually. 