### PR TITLE
Use closure actions to make deprecation removal possible

### DIFF
--- a/addon/components/copy-button.js
+++ b/addon/components/copy-button.js
@@ -53,7 +53,14 @@ export default Component.extend({
       clipboard.on(action, run.bind(this, e => {
         try {
           if (!this.get('disabled')) {
-            this.sendAction(action, e);
+            const actionRetrieved = this.get(action);
+
+            if (typeof(actionRetrieved) === 'string') {
+              // Note that `sendAction` is deprecated and this will trigger a deprecation message.
+              this.sendAction(actionRetrieved, e);
+            } else if (typeof(actionRetrieved) === 'function') {
+              actionRetrieved(e);
+            }
           }
         }
         catch(error) {

--- a/tests/integration/components/copy-button-test.js
+++ b/tests/integration/components/copy-button-test.js
@@ -95,6 +95,30 @@ test('error action fires', function(assert) {
   this.$('button').click();
 });
 
+test('error action defined as closure action fires', function(assert) {
+  assert.expect(1);
+
+  this.set('error', () => {
+    assert.ok(true, 'error action successfully called');
+  });
+
+  this.render(hbs`
+    {{#copy-button
+      clipboardText='text'
+      success='success'
+      error=(action error)
+    }}
+      Click To Copy
+    {{/copy-button}}
+  `);
+
+  /*
+   * Can only directly test error case here b/c browsers do not allow simulated
+   * clicks for `execCommand('copy')`. See test-helpers to test action integration.
+   */
+  this.$('button').click();
+});
+
 test('error action fires with delegateClickEvent: false', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Ember added a new deprecation in v3.4: https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_ember-component-send-action

This PR adds a support for closure actions for this addon.