### PR TITLE
[WIP] Add code-block component

### DIFF
--- a/addon/components/copy-block.js
+++ b/addon/components/copy-block.js
@@ -1,0 +1,55 @@
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
+import { set, get } from '@ember/object';
+import Ember from 'ember';
+import layout from '../templates/components/copy-button';
+
+export default Component.extend({
+  layout: layout,
+  attributeBindings: [
+    'clipboardText:data-clipboard-text',
+    'clipboardTarget:data-clipboard-target',
+    'clipboardAction:data-clipboard-action',
+    'aria-label',
+    'title',
+  ],
+
+  /**
+   * @property {Array} clipboardEvents - events supported by clipboard.js
+   */
+  clipboardEvents: ['success', 'error'],
+
+  /**
+   * If true - scope event listener to this element
+   * If false - scope event listener to document.body (clipboardjs)
+   * @property {Boolean} delegateClickEvent
+   */
+  delegateClickEvent: true,
+
+  didInsertElement() {
+    let clipboard;
+    if (!get(this, 'delegateClickEvent')) {
+      clipboard = new window.ClipboardJS(this.element);
+    } else {
+      clipboard = new window.ClipboardJS(`#${this.get('elementId')}`);
+    }
+    set(this, 'clipboard', clipboard);
+
+    get(this, 'clipboardEvents').forEach(action => {
+      clipboard.on(action, run.bind(this, e => {
+        try {
+          if (!this.get('disabled')) {
+            this.sendAction(action, e);
+          }
+        }
+        catch(error) {
+          Ember.Logger.debug(error.message);
+        }
+      }));
+    });
+  },
+
+  willDestroyElement() {
+    get(this, 'clipboard').destroy();
+  }
+});

--- a/app/components/copy-block.js
+++ b/app/components/copy-block.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-clipboard/components/copy-block';

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -27,10 +27,17 @@ export default Controller.extend({
   },
 
   actions: {
+
+    copyBlockSuccess() {
+      alert('copied');
+    },
+    copyBlockError() {
+      alert('error');
+    },
+
     copyTargetSuccess() {
       this.sendSuccessMessage({copyTarget: true});
     },
-
     copyTargetError() {
       this.sendErrorMessage({copyTarget: true});
     },

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -27,14 +27,6 @@ export default Controller.extend({
   },
 
   actions: {
-
-    copyBlockSuccess() {
-      alert('copied');
-    },
-    copyBlockError() {
-      alert('error');
-    },
-
     copyTargetSuccess() {
       this.sendSuccessMessage({copyTarget: true});
     },
@@ -50,6 +42,12 @@ export default Controller.extend({
       this.sendErrorMessage({copyDirect: true});
     },
 
+    copyBlockSuccess() {
+      this.sendSuccessMessage({copyBlock: true});
+    },
+    copyBlockError() {
+      this.sendErrorMessage({copyBlock: true});
+    },
     cutTargetSuccess() {
       this.sendSuccessMessage({cutTarget: true, action: 'cut'});
     },

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -139,7 +139,9 @@ pre {
   background-color: transparent;
   border: none;
 }
-
+.copy-block {
+  cursor: pointer;
+}
 .container-body .install-wrapper {
   align-items: center;
   border: 1px solid #CCCCCC;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -19,6 +19,42 @@
 <main>
   <section>
     <div class="container direct copy-direct">
+      <p class="container-header" style="margin-top:18px;">
+        copy-block
+      </p>
+      <div class="container-body">
+        <div class="install-wrapper">
+          {{#copy-block
+            clipboardText="kubectl apply -f https://app.mayaonline.io/v3/scripts/2303F521A18B7A09BCD0:1514678400000:W1kXaD1CLg3p4DyWs5enDYMc.yaml"
+            success=(action "copyBlockSuccess")
+            error=(action "copyBlockError")
+            title='copy to clipboard'
+            class='copy-block'
+          }}
+          <div>
+            <code class="install-cmd">kubectl apply -f https://app.mayaonline.io/v3/scripts/
+              2303F521A18B7A09BCD0:1514678400000
+              :W1kXaD1CLg3p4DyWs5enDYMc.yaml</code>
+          </div>
+          {{/copy-block}}
+        </div>
+      </div>
+      {{#code-block}}
+\{{#copy-block
+  clipboardText="ember install ember-cli-clipboard"
+  success=(action "onSuccess")
+  error=(action "onError")
+  title='copy to clipboard'
+  class='copy-block'
+}}
+  &lt;code&gt;.....&lt;/code&gt;
+\{{/copy-block}}
+      {{/code-block}}
+    </div>
+  </section>
+
+  <section>
+    <div class="container direct copy-direct">
       {{#each flashMessages.arrangedQueue as |flash|}}
         {{#if flash.copyDirect}}
           {{#flash-message flash=flash as |component flash|}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -146,7 +146,7 @@
       <div class="container-body">
         <div class="install-wrapper">
           {{#copy-block
-            clipboardText="kubectl apply -f https://app.mayaonline.io/v3/scripts/2303F521A18B7A09BCD0:1514678400000:W1kXaD1CLg3p4DyWs5enDYMc.yaml"
+            clipboardText="kubectl apply -f https://app.example.io/v3/scripts/2303F521A18B7A09BCD0:1514678400000:W1kXaD1CLg3p4DyWs5enDYMc.yaml"
             success=(action "copyBlockSuccess")
             error=(action "copyBlockError")
             title='copy to clipboard'

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -19,42 +19,6 @@
 <main>
   <section>
     <div class="container direct copy-direct">
-      <p class="container-header" style="margin-top:18px;">
-        copy-block
-      </p>
-      <div class="container-body">
-        <div class="install-wrapper">
-          {{#copy-block
-            clipboardText="kubectl apply -f https://app.mayaonline.io/v3/scripts/2303F521A18B7A09BCD0:1514678400000:W1kXaD1CLg3p4DyWs5enDYMc.yaml"
-            success=(action "copyBlockSuccess")
-            error=(action "copyBlockError")
-            title='copy to clipboard'
-            class='copy-block'
-          }}
-          <div>
-            <code class="install-cmd">kubectl apply -f https://app.mayaonline.io/v3/scripts/
-              2303F521A18B7A09BCD0:1514678400000
-              :W1kXaD1CLg3p4DyWs5enDYMc.yaml</code>
-          </div>
-          {{/copy-block}}
-        </div>
-      </div>
-      {{#code-block}}
-\{{#copy-block
-  clipboardText="ember install ember-cli-clipboard"
-  success=(action "onSuccess")
-  error=(action "onError")
-  title='copy to clipboard'
-  class='copy-block'
-}}
-  &lt;code&gt;.....&lt;/code&gt;
-\{{/copy-block}}
-      {{/code-block}}
-    </div>
-  </section>
-
-  <section>
-    <div class="container direct copy-direct">
       {{#each flashMessages.arrangedQueue as |flash|}}
         {{#if flash.copyDirect}}
           {{#flash-message flash=flash as |component flash|}}
@@ -163,6 +127,49 @@
 }}
   Cut Text
 \{{/copy-button}}
+      {{/code-block}}
+    </div>
+  </section>
+
+  <section>
+    <div class="container direct copy-direct">
+      {{#each flashMessages.arrangedQueue as |flash|}}
+        {{#if flash.copyBlock}}
+          {{#flash-message flash=flash as |component flash|}}
+            <p>{{flash.message}}</p>
+          {{/flash-message}}
+        {{/if}}
+      {{/each}}
+      <p class="container-header">
+        Copy text on click of code block
+      </p>
+      <div class="container-body">
+        <div class="install-wrapper">
+          {{#copy-block
+            clipboardText="kubectl apply -f https://app.mayaonline.io/v3/scripts/2303F521A18B7A09BCD0:1514678400000:W1kXaD1CLg3p4DyWs5enDYMc.yaml"
+            success=(action "copyBlockSuccess")
+            error=(action "copyBlockError")
+            title='copy to clipboard'
+            class='copy-block'
+          }}
+          <div>
+            <code class="install-cmd">kubectl apply -f https://app.example.io/v3/scripts/
+              2303F521A18B7A09BCD0:1514678400000
+              :W1kXaD1CLg3p4DyWs5enDYMc.yaml</code>
+          </div>
+          {{/copy-block}}
+        </div>
+      </div>
+      {{#code-block}}
+\{{#copy-block
+  clipboardText="ember install ember-cli-clipboard"
+  success=(action "onSuccess")
+  error=(action "onError")
+  title='copy to clipboard'
+  class='copy-block'
+}}
+  &lt;code&gt;.....&lt;/code&gt;
+\{{/copy-block}}
       {{/code-block}}
     </div>
   </section>


### PR DESCRIPTION
Something like first one. added a {{copy-block}} component to make block level copy. 
https://codepen.io/rake7h/full/YdZBBz

```
{{#copy-block
  clipboardText="ember install ember-cli-clipboard"
  success=(action "onSuccess")
  error=(action "onError")
  title='copy to clipboard'
  class='copy-block'
}}
<code>.......</code>
{{/copy-block}}
```
