### PR TITLE
fix issue in ie

### DIFF
--- a/addon/components/copy-button.js
+++ b/addon/components/copy-button.js
@@ -77,6 +77,8 @@ export default Component.extend({
   },
 
   willDestroyElement() {
-    this.clipboard.destroy();
+    if (this.clipboard) {
+      this.clipboard.destroy();
+    }
   }
 });


### PR DESCRIPTION
seeing issue in ie11 where if copy button exists in document and user tries to transition away from the page and fails when copy button is tearing down 