### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,9 @@
     "ember-cli": "~3.9.0",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^4.2.3",
-    "ember-cli-fastboot": "^1.0.5",
+    "ember-cli-fastboot": "^2.0.4",
     "ember-cli-flash": "^1.4.2",
-    "ember-cli-github-pages": "0.1.2",
-    "ember-cli-htmlbars": "^3.0.0",
+    "ember-cli-github-pages": "^0.2.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-sri": "^2.1.1",
@@ -48,8 +47,8 @@
     "broccoli-funnel": "^1.1.0",
     "clipboard": "^2.0.0",
     "ember-cli-babel": "^7.1.2",
-    "ember-cli-htmlbars": "^2.0.2",
-    "fastboot-transform": "0.1.1"
+    "ember-cli-htmlbars": "^3.0.1",
+    "fastboot-transform": "^0.1.3"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
- Fix vulnerable dependency warnings
- Use fastboot-transform@0.1.3 to fix #56
- Use ember-cli-htmlbars@3.0.1