### PR TITLE
Handle "container" option of clipboardJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ http://jkusa.github.io/ember-cli-clipboard
 - `clipboardText` - string value or action that returns a string to be copied
 - `clipboardTarget` - selector string of element from which to copy text
 - `clipboardAction` - string value of operation: `copy` or `cut` (default is copy)
+- `container` - selector string or element object of containing element. "For use in Bootstrap Modals or with any other library that changes the focus you'll want to set the focused element as the container value".
 - `delegateClickEvent` - clipboard.js defaults event listeners to the body in order to reduce memory footprint if there are hundreds of event listeners on a page. If you want to scope the event listener to the copy button, set this property to `false`
 - `buttonType` - string value of the button's [type attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes)
 

--- a/addon/components/copy-button.js
+++ b/addon/components/copy-button.js
@@ -60,7 +60,7 @@ export default class CopyButtonComponent extends Component {
    * @returns {Object} newly created ClipboardJS object
    */
   _createClipboard() {
-    const { clipboardText: text, delegateClickEvent } = this;
+    const { clipboardText: text, container, delegateClickEvent } = this;
     const trigger =
       delegateClickEvent === false
         ? this._buttonElement
@@ -68,6 +68,10 @@ export default class CopyButtonComponent extends Component {
 
     return new ClipboardJS(trigger, {
       text: typeof text === 'function' ? text : undefined,
+      container:
+        typeof container === 'string'
+          ? document.querySelector(container)
+          : container,
     });
   }
 


### PR DESCRIPTION
This PR handles the `container` option of ClipboardJS, as described [here](https://github.com/zenorocha/clipboard.js/pull/368).This `container` option allows the clipboard to work in modals, which will fix issue #180 