### PR TITLE
return clipboard event as a callback for success and failure listener

### DIFF
--- a/addon/components/copy-button.js
+++ b/addon/components/copy-button.js
@@ -83,14 +83,14 @@ export default class CopyButtonComponent extends Component {
    */
   _registerActions(clipboard) {
     CLIPBOARD_EVENTS.forEach((event) => {
-      clipboard.on(event, () => {
+      clipboard.on(event, (clipboardEvent) => {
         if (!this._buttonElement.disabled) {
           const action = this[event];
           if (typeof action === 'string') {
             // eslint-disable-next-line ember/closure-actions
-            this.sendAction(action, ...arguments);
+            this.sendAction(action, clipboardEvent);
           } else {
-            action && action(...arguments);
+            action && action(clipboardEvent);
           }
         }
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-clipboard",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Clipboard.js button component",
   "scripts": {
     "build": "ember build --environment=production",


### PR DESCRIPTION
When bumping version from v0.10.0 to v0.11.0 the clipboard event should be given in the callback but it was missed.