### PR TITLE
drop schedule setting for ci.yml config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
     # filtering branches here prevents duplicate builds from pull_request and push
     branches:
       - main
-  schedule:
-    - cron: '0 3 * * 0' # every Sunday at 3am
 
 env:
   CI: true


### PR DESCRIPTION
the scheduled CI.yml config disabled:
![Selection_583](https://user-images.githubusercontent.com/23525618/124356930-55269700-dc32-11eb-8d6f-c1207fb92840.jpg)
so, probably, because of this, we have no runs in PR's, only lint.yml triggered, see example:
![Selection_584](https://user-images.githubusercontent.com/23525618/124356960-87d08f80-dc32-11eb-9fad-378f33cc6581.jpg)
https://github.com/jkusa/ember-cli-clipboard/pull/357