### PR TITLE
relax `@ember/render-modifiers` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "uuid": "^8.3.0"
   },
   "dependencies": {
-    "@ember/render-modifiers": "^1.0.1",
+    "@ember/render-modifiers": "^1.0.2 || ^2.0.0",
     "clipboard": "^2.0.6",
     "ember-auto-import": "^1.10.1",
     "ember-cli-babel": "^7.23.1",


### PR DESCRIPTION
Since the public api didn't change, it shouldn't really matter for this addon wether the `@ember/render-modifiers` version is v1 or v2.
This allows people to update their ember apps.